### PR TITLE
fix: wrong parameter name for DuckDNS

### DIFF
--- a/dynb.sh
+++ b/dynb.sh
@@ -284,7 +284,7 @@ function dynupdate
       ;;
     DuckDNS* | duckdns*)
       dyndns_update_url="${DUCKDNS_DYNDNS_UPDATE_URL}"
-      myip_str=ipv4
+      myip_str=ip
       myipv6_str=ipv6
       ;;
     *)


### PR DESCRIPTION
closes #5 

- [x] test